### PR TITLE
[Fix] Must use import to load ES Module (escape-string-regexp)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,15 +1,6 @@
 const esModules = ['escape-string-regexp'].join('|');
 
 module.exports = {
-  globals: {
-    'ts-jest': {
-      diagnostics: {
-        ignoreCodes: [
-          'TS7006', /* Parameter 'string' implicitly has an 'any' type. */
-        ],
-      },
-    },
-  },
   roots: ['<rootDir>/src/', '<rootDir>/test/'],
   transform: {
     '^.+\\.[tj]sx?$': 'ts-jest',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,7 @@
 
     /* Strict Type-Checking Options */
     "strict": true                            /* Enable all strict type-checking options. */,
-    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    "noImplicitAny": false                    /* Raise error on expressions and declarations with an implied 'any' type. */,
     // "strictNullChecks": true,              /* Enable strict null checks. */
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
     // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
@@ -69,6 +69,6 @@
     "pretty": false,
     "skipLibCheck": true
   },
-  "include": ["src/"],
+  "include": ["src/", "node_modules/escape-string-regexp/"],
   "compileOnSave": false
 }


### PR DESCRIPTION
Adds _escape-string-regexp_ to TypeScript's `include` array.